### PR TITLE
Expose args as a param to cli.run

### DIFF
--- a/appimagelint/cli.py
+++ b/appimagelint/cli.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 
-from appimagelint.services.checks_manager import ChecksManager
+from .services.checks_manager import ChecksManager
 from .cache.runtime_cache import AppImageRuntimeCache
 from .reports import JSONReport
 from .services.result_formatter import ResultFormatter
@@ -15,7 +15,7 @@ from .checks import IconsCheck, GlibcABICheck, GlibcxxABICheck, DesktopFilesChec
 def get_version():
     try:
         import pkg_resources
-        version = pkg_resources.require("appimagelint")[0].version
+        version = '0.0.1'
     except ImportError:
         version = "unknown"
 

--- a/appimagelint/cli.py
+++ b/appimagelint/cli.py
@@ -35,7 +35,7 @@ def get_version():
     return version
 
 
-def parse_args():
+def parse_args(args=None):
     parser = argparse.ArgumentParser(
         prog="appimagelint",
         description="Run compatibility and other checks on AppImages automatically, "
@@ -80,15 +80,15 @@ def parse_args():
                         nargs="+",
                         help="AppImage to review")
 
-    args = parser.parse_args()
+    parsed_args = parser.parse_args(args)
 
-    return args
+    return parsed_args
 
 
-def run():
+def run(args=None):
     ChecksManager.init()
 
-    args = parse_args()
+    args = parse_args(args)
 
     if getattr(args, "display_version", False):
         print(get_version())


### PR DESCRIPTION
It would be nice if I could provide `args="--help"` to `cli.run` making it accessible from other python software. What do you think?
https://github.com/TheAssassin/appimagelint/commit/804e859138c177b20794244337dd14a6638ce283 is an optional commit, feel free to pop the commit, but I would be happy, making appimagelint accessible to other python software, for example [`pyappimage`](/srevinsaju/pyappimage) where I can run appimagelint after creating the appimage